### PR TITLE
Remove old delete stack builds

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -17,7 +17,11 @@
                     "develop",
                     "refs/heads/develop"
                 ].indexOf(branch.name) > -1
-            )           
+            )
+           && (
+           	branch.buildType.name.indexOf("Delete stack") === -1
+           	||  !!branch.name
+           ) 
         );
     },
 };


### PR DESCRIPTION
Previously we had the Delete stack bulids without any branches. Now we it is bound to dev/release etc. branches.